### PR TITLE
Convert PostgreSQL decimal/numeric values to FLOAT64.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "config",
     "redis",
     "routes",
-    "error_handling"
+    "error_handling",
+    "debezium"
   ]
 }

--- a/backend/src/utils/utils.ts
+++ b/backend/src/utils/utils.ts
@@ -54,7 +54,8 @@ export const setupConnectorPayload = (source: SourceRequestBody) => {
       'database.password': source.password,
       'database.dbname': source.dbName,
       'topic.prefix': 'dbserver1', //must agree on how to define this for each connector!!!!
-      'skipped.operations': 'none'
+      'skipped.operations': 'none',
+      "decimal.handling.mode": "double"
     },
   };
 


### PR DESCRIPTION
By [default](https://debezium.io/documentation/reference/2.4/connectors/postgresql.html#postgresql-decimal-types), Debezium's `decimal.handling.mode` is set to `precise`. This means that any `numeric`/`decimal` values in Postgres get converted by Debezium into either BYTES or a STRUCT containing info on the value's scale & the actual value in BYTES. This would require some kind of complex conversion to handle appropriately. 

This PR sets Debezium's `decimal.handling.mode` to [`double`](https://debezium.io/documentation/reference/2.4/connectors/postgresql.html#postgresql-decimal-types:~:text=When%20the%20decimal.handling.mode%20property%20is%20set%20to%20double%2C%20the%20connector%20represents%20all%20DECIMAL%2C%20NUMERIC%20and%20MONEY%20values%20as%20Java%20double%20values%20and%20encodes%20them%20as%20shown%20in%20the%20following%20table.), which tells Debezium to convert the `numeric`/`decimal` Postgres values into FLOAT64, which is the type we need those values in. 

Having Debezium do the conversion into FLOAT64 for us instead of our application doing the conversion with the BYTES/STRUCT data may result in a min/max/precision limit to what we can accurately convert from Postgres, but I think that is acceptable so we can continue moving forward. If the min/max/precision limit is an issue, we can revisit & determine how to use the BYTES/STRUCT data to do the conversion ourselves.

This PR can be tested & checked by creating a table with `decimal`/`numeric` values, inserting some data, then making sure that data is correctly represented in the logs / Redis.

SQL to create a `numbers` table and insert some data:
```SQL
CREATE TABLE numbers (
  id serial PRIMARY KEY,
  integer integer NOT NULL,
  numericNoScale numeric NOT NULL,
  numeric numeric(4, 2) NOT NULL
);

INSERT INTO numbers (integer, numericNoScale, numeric) VALUES (43, 1.234, 56.78);
```

The backend container logs will contain the following with different time stamps:
```
2024-03-16 14:20:33 Redis key should be:  test.numbers.1
2024-03-16 14:20:33 Performing r operation on Redis key  test.numbers.1
2024-03-16 14:20:33 Setting Redis key test.numbers.1 to value:  { id: 1, integer: 43, numericnoscale: 1.234, numeric: 56.78 }
```