### PR TITLE
Prevent tables with no primary keys from being shown.

### DIFF
--- a/frontend/src/components/SelectDataForm.tsx
+++ b/frontend/src/components/SelectDataForm.tsx
@@ -119,7 +119,7 @@ const SelectDataForm = ({
       const currentSchemaTables = rawTablesAndColumnsData[i].tables;
       for (let j = 0; j < currentSchemaTables.length; j++) {
         const currentTable = currentSchemaTables[j];
-        if (currentTable.primaryKeys.length < 1) {continue}
+        const hasPrimaryKeys = currentTable.primaryKeys.length > 0;
         result.push({
           table_name: currentTable.table_name,
           schema_name: rawTablesAndColumnsData[i].schema_name,
@@ -131,7 +131,8 @@ const SelectDataForm = ({
               dbzColumnValue: `${rawTablesAndColumnsData[i].schema_name}.${currentTable.table_name}.${column}`,
             };
           }),
-          selected: true,
+          selected: hasPrimaryKeys,
+          visible: hasPrimaryKeys,
         });
       }
     }
@@ -171,6 +172,7 @@ const SelectDataForm = ({
               >
                 {formData.map((data) => {
                   return (
+                    data.visible &&
                     <ListItem
                       sx={{ padding: 0 }}
                       key={`${data.schema_name}.${data.table_name}`}

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -43,6 +43,7 @@ interface SelectDataFormDataObj {
   dbzTableValue: string;
   columns: SelectDataFormColumnObj[];
   selected: boolean;
+  visible: boolean;
 }
 
 export type SelectDataFormData = SelectDataFormDataObj[];


### PR DESCRIPTION
Since the backend now sends the list of each table's primary keys as part of the response to the `/source/verify` route, we can prevent tables with no primary keys from being visible in the SELECT DATA form. 

However, we must still include them in the `formData` with their `selected` property set to `false` since the Debezium configuration lists tables that are excluded, which must include tables with no primary keys.

