### PR TITLE
Fix bug to allow minimum privileged source DB user

### DIFF
--- a/backend/src/utils/utils.ts
+++ b/backend/src/utils/utils.ts
@@ -158,6 +158,7 @@ export const setupConnectorPayload = (source: FinalSourceRequestBody) => {
       'decimal.handling.mode': 'double',
       'publication.name': 'willow_publication',
       'slot.name': `willow_${uuid}`,
+      'publication.autocreate.mode': 'filtered',
     },
   };
 


### PR DESCRIPTION
To allow the Debezium connector to work successfully with a source database user that has the [minimum required privileges](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-permissions) (i.e. not a SUPERUSER account), a few things were changed in our code:
1. The [`publication.autocreate.mode`](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-publication-autocreate-mode) was specified in the `setupConnectorPayload` method to be `filtered`. This overrides the Debezium default of `all_tables`, which tries to create a publication for all tables in the database. If the user does not have the appropriate privileges for at least one table in the database, attempting to create a publication using `all_tables` fails. When we specify `filtered`, then Debezium only tries to make a publication for the tables specified in the configuration's `table.include.list`/`table.exclude.list` and `schema.include.list`/`schema.exclude.list`. As long as the user has the appropriate privileges for the included / not excluded tables, then the publication creation succeeds.

2. The `addTablesAndColumnsToConfig` was changed to use `table.include.list` instead of `table.exclude.list`. By specifying which tables are included, we avoid a bug where if a non-public schema exists with tables that the user does not have access to, then the connector fails since Debezium will try to create a publication for those tables in the non-public schema. This happened because that private schema & table were not excluded. Moving to exclude these types of private schemas would add a lot more complexity, and it's significantly easier to just specify exactly which tables to include instead & avoid this bug.

After these changes, our application works with a source database user with minimum privileges.

With help from the [Debezium docs](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-publication-autocreate-mode), I setup a `my_database` database in my PostgreSQL server for testing by using the below commands:
```sql
CREATE DATABASE my_database;

-- switch to working in the new database we just created, my_database

-- create tables in the public schema

CREATE TABLE table_1 (
  id serial PRIMARY KEY,
  data varchar
);

CREATE TABLE table_2 (
  id serial PRIMARY KEY,
  data varchar
);

CREATE TABLE table_3 (
  id serial PRIMARY KEY,
  data varchar
);

INSERT INTO table_1 (data) VALUES ('This is table 1!');
INSERT INTO table_2 (data) VALUES ('This is table 2!');
INSERT INTO table_3 (data) VALUES ('This is table 3!');

-- create a table in a private schema that willow won't have access to

CREATE SCHEMA private_schema;

CREATE TABLE private_schema.table_a (
  id serial PRIMARY KEY,
  data varchar
);

INSERT INTO private_schema.table_a (data) VALUES ('This is table a in the private schema!');

-- Create the willow role with limited permissions (can only access table_1 and table_2 in the my_database DB).

CREATE ROLE willow REPLICATION LOGIN;
ALTER USER willow WITH PASSWORD 'password';

CREATE ROLE replication;

GRANT replication TO alexbair;
GRANT replication TO willow;

ALTER TABLE table_1 OWNER TO replication;
ALTER TABLE table_2 OWNER TO replication;

-- Give willow user CREATE privileges on the my_database DB. This lets willow create publications in the DB.
GRANT CREATE ON DATABASE my_database TO willow;
```