### PR TITLE
Routes Refactoring

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,8 +13,8 @@ app.use(express.json());
 app.use(cors());
 app.use(morgan("common"));
 
-app.use('/consumer', sinkRoutes);
-app.use('/source', sourceRoutes);
+app.use('/sinks', sinkRoutes);
+app.use('/sources', sourceRoutes);
 app.use('/pipelines', pipelineRoutes);
 
 app.use(unknownEndpointHandler);

--- a/backend/src/routes/sinkRoutes.ts
+++ b/backend/src/routes/sinkRoutes.ts
@@ -10,7 +10,7 @@ import { parseSourceName } from '../utils/routeHelpers';
 
 const router = express.Router();
 
-router.post('/check', async (req: TypedRequest<SinkRequestBody>, res, next) => {
+router.post('/verify', async (req: TypedRequest<SinkRequestBody>, res, next) => {
   const { url, username, password } = req.body;
   try {
     validateSinkConnectionDetails(url, username, password);
@@ -40,7 +40,7 @@ router.post('/create', async (req: TypedRequest<SinkRequestBody>, res, next) => 
 
     sinks.add(connectionName, consumer);
 
-    res.json({ message: 'Consumer created!' });
+    res.status(201).json({ message: 'Consumer created!' });
   } catch (err) {
     next(err);
   }

--- a/backend/src/routes/sourceRoutes.ts
+++ b/backend/src/routes/sourceRoutes.ts
@@ -31,7 +31,7 @@ router.post('/verify', async (req: TypedRequest<SourceRequestBody>, res, next) =
   }
 });
 
-router.post('/connect', async (req: TypedRequest<FinalSourceRequestBody>, res, next) => {
+router.post('/create', async (req: TypedRequest<FinalSourceRequestBody>, res, next) => {
   const source = req.body;
   const kafkaConnectPayload = setupConnectorPayload(source);
   const database = new Database('postgres://postgres:postgres@db:5432');
@@ -58,7 +58,7 @@ router.post('/connect', async (req: TypedRequest<FinalSourceRequestBody>, res, n
 
     await database.end();
 
-    res.json({ message: 'Source connector created!' });
+    res.status(201).json({ message: 'Source connector created!' });
   } catch (error) {
     next(error);
   }

--- a/frontend/src/services/sink.ts
+++ b/frontend/src/services/sink.ts
@@ -3,7 +3,7 @@ import { RedisSinkFormState, RedisConnectionDetails } from "../types/types";
 
 export const postSinkVerify = async (formState: RedisConnectionDetails) => {
   const { data } = await axios.post(
-    "http://localhost:3000/consumer/check", // this would need to be 'backend' instead of localhost in the future
+    "http://localhost:3000/sinks/verify",
     formState
   );
   return data.data;
@@ -11,7 +11,7 @@ export const postSinkVerify = async (formState: RedisConnectionDetails) => {
 
 export const postSinkCreate = async (formState: RedisSinkFormState) => {
   const { data } = await axios.post(
-    "http://localhost:3000/consumer/create", // this would need to be 'backend' instead of localhost in the future
+    "http://localhost:3000/sinks/create",
     formState
   );
   return data.data;

--- a/frontend/src/services/source.ts
+++ b/frontend/src/services/source.ts
@@ -9,7 +9,7 @@ export const postSourceVerify = async (
   formState: SourceFormConnectionDetails
 ) => {
   const { data } = await axios.post(
-    "http://localhost:3000/source/verify", // this would need to be 'backend' instead of localhost in the future
+    "http://localhost:3000/sources/verify",
     formState
   );
   return data.data as rawTablesAndColumnsData;
@@ -19,7 +19,7 @@ export const postSourceKafkaConnect = async (
   KafkaConnectPayload: KafkaConnectPayload
 ) => {
   const { data } = await axios.post(
-    "http://localhost:3000/source/connect", // this would need to be 'backend' instead of localhost in the future
+    "http://localhost:3000/sources/create",
     KafkaConnectPayload
   );
   return data.data;


### PR DESCRIPTION
PR scope includes:
- Renaming routes to align with each other (`/verify` for verifying a connection, `/create` for actually creating a connector).
- Renamed the `/consumer` route to be `/sink` to align with more standard terminology used in CDC.
- Made route resource names plural (`/source` became `/sources`, `/sink` became `/sinks`).
- Responds with a `201` status code when a source or a sink is successfully created.