### PR TITLE
Fix bug that caused custom backend Docker container to crash.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,4 +3,4 @@ FROM node:21.7
 WORKDIR /usr/src
 COPY . /usr/src
 RUN npm install
-CMD "npm" "start"
+CMD ["npm", "run", "docker:start"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "test": "NODE_ENV=test jest --verbose --runInBand --forceExit",
     "dev": "NODE_ENV=development ts-node-dev src/index.ts",
     "start": "npm run build:ui && NODE_ENV=production ts-node src/index.ts",
+    "docker:start": "NODE_ENV=production ts-node src/index.ts",
     "tsc": "tsc"
   },
   "keywords": [],


### PR DESCRIPTION
Since we updated the `npm start` script to build the `dist` directory, and our Dockerfile used `npm start` to run our application, the backend docker container would crash since it did not have access to the `frontend` directory. This is addressed by adding a custom `docker:start` npm script that relies on the `dist` directory already being built and does not try to rebuild it.